### PR TITLE
Runtime logic improvement: add Custodian Role

### DIFF
--- a/res/custom_types.json
+++ b/res/custom_types.json
@@ -2,7 +2,8 @@
     "Order": {
         "model": "Vec<u8>",
         "objective": "Vec<u8>",
-        "cost": "Balance"
+        "cost": "Balance",
+        "custodian": "AccountId"
     },
     "Demand": {
         "order": "Order",


### PR DESCRIPTION
Currently, *promisor* finalizes liability by himself. This allows him to misbehavior and take the money without really executing the order. We need a third party here, let's call him *custodian*, who verifies the order execution and finalizes the liability.