### PR TITLE
feat(runtime): mint 0.0042 XRT per block to collator (issue #510)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11712,6 +11712,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "robonomics-collator-rewards"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-authorship",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 39.0.0",
+ "sp-io 44.0.0",
+ "sp-runtime 45.0.0",
+]
+
+[[package]]
 name = "robonomics-runtime"
 version = "4.2.0"
 dependencies = [
@@ -11768,6 +11783,7 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-runtime-common",
+ "robonomics-collator-rewards",
  "scale-info",
  "serde_json",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
   "frame/launch",
   "frame/datalog",
   "frame/liability",
+  "frame/collator-rewards",
   "frame/digital-twin",
   "frame/cps",
   "frame/claim",
@@ -240,6 +241,7 @@ pallet-robonomics-rws = { path = "./frame/rws", default-features = false }
 pallet-robonomics-cps = { path = "./frame/cps", default-features = false }
 pallet-robonomics-claim = { path = "./frame/claim", default-features = false }
 pallet-robonomics-teleport = { path = "./frame/teleport", default-features = false }
+robonomics-collator-rewards = { path = "./frame/collator-rewards", default-features = false }
 parachain-info = { path = "./frame/parachain-info", default-features = false }
 
 # Robonomics runtimes

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -167,14 +167,15 @@ Typical steps:
 
 ## Collator Rewards
 
-Collator rewards on Robonomics are **transaction fee-based only** — there is no fixed block reward.
+Collators earn from two sources:
 
-The fee distribution mechanism (see `DealWithFees` in `runtime/robonomics/src/lib.rs`):
-
-1. **100% of transaction fees and tips** are routed to the `PotStake` account managed by `pallet_collator_selection`.
-2. The block author receives a share from the pot when producing a block.
-
-At low network utilization, collator rewards are minimal. This is important to consider when planning collator operations.
+1. **Per-block author reward** — a fixed `0.0042 XRT` is minted directly to the
+   block author every block. See [Per-Block Author Reward](#per-block-author-reward)
+   below.
+2. **Transaction fees and tips** — `100 %` of fees and tips are routed to the
+   `PotStake` account managed by `pallet_collator_selection` (see
+   `DealWithFees` in `runtime/robonomics/src/lib.rs`); the block author then
+   receives a share from that pot when producing a block.
 
 ### Hardware Cost Estimate
 
@@ -185,8 +186,69 @@ At low network utilization, collator rewards are minimal. This is important to c
 | Storage | 1 TB NVMe | 2 TB NVMe |
 | Estimated cost | ~$80–120/mo | ~$120–150/mo |
 
+## Per-Block Author Reward
+
+Starting from spec_version **43**, the Robonomics Polkadot parachain mints a
+**fixed per-block reward of `0.0042 XRT` directly to the block author** (in
+addition to any transaction fees and tips collected by `pallet_collator_selection`).
+
+The reward is implemented by an `AuthorRewards` event handler wired into
+`pallet_authorship::Config::EventHandler` *before* `CollatorSelection`. It
+mints directly into the author's account so the author receives the full
+reward, rather than half of it (which would happen if the reward were paid
+into the `PotStake` account, since
+`pallet_collator_selection::note_author` distributes only **half** of the pot
+to the current author).
+
+### Formula
+
+```
+reward_per_block =
+    (server_cost_per_year * number_of_collators * 1.3)
+    / number_of_blocks_per_year
+    / XRT_price
+```
+
+Substituting the values from issue #510:
+
+| Parameter              | Value                                 |
+| ---------------------- | ------------------------------------- |
+| Server cost / year     | `$2_040` (OVH Epyc 4345P, 64 GB, 2×960 GB NVMe) |
+| Minimum collators      | `7`                                   |
+| Profit margin          | `30 %` (factor `1.3`)                 |
+| Avg block time         | `7 s` ⇒ `4_505_143` blocks / year     |
+| XRT price              | `$1`                                  |
+
+```
+(2_040 * 7 * 1.3) / 4_505_143 / 1  ≈  0.004120624 XRT
+                                   ≈  0.0042 XRT  (rounded up)
+```
+
+Encoded constant in `runtime/robonomics/src/lib.rs`:
+
+```rust
+pub const COLLATOR_BLOCK_REWARD: Balance = 4_200_000; // 0.0042 XRT (9 decimals)
+```
+
+### When to revisit
+
+The reward should be recalculated and a new runtime upgrade shipped whenever
+**any** of the input parameters change significantly:
+
+* the cost of the reference hardware moves materially up or down,
+* the minimum desired number of active collators changes,
+* the actual average block time drifts (changing the blocks-per-year base),
+* the XRT market price moves enough that the resulting USD-equivalent reward
+  no longer covers the reference hardware cost plus a 30 % margin.
+
+When updating the reward, change `COLLATOR_BLOCK_REWARD`, bump `spec_version`,
+and update both the table above and the unit tests in
+`runtime/robonomics/src/lib.rs::author_rewards_tests`.
+
 ## Disk Requirements
 
 * **Kusama:** parachain ~235 GB + relay chain ~550 GB (growing). Minimum **1 TB** recommended.
 * **Polkadot:** parachain + relay chain ~1.1 TB (growing). Minimum **2 TB** recommended.
 * **Running both networks:** minimum **5 TB** recommended.
+
+

--- a/frame/collator-rewards/Cargo.toml
+++ b/frame/collator-rewards/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "robonomics-collator-rewards"
+description = "Generic per-block collator (block author) reward helper for Robonomics runtimes"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+sp-runtime = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+pallet-authorship = { workspace = true }
+
+[dev-dependencies]
+sp-core = { workspace = true, features = ["std"] }
+sp-io = { workspace = true, features = ["std"] }
+pallet-balances = { workspace = true, features = ["std"] }
+
+[features]
+default = ["std"]
+std = [
+  "parity-scale-codec/std",
+  "scale-info/std",
+  "sp-runtime/std",
+  "frame-support/std",
+  "frame-system/std",
+  "pallet-authorship/std",
+]
+try-runtime = [
+  "frame-support/try-runtime",
+  "frame-system/try-runtime",
+  "pallet-authorship/try-runtime",
+  "sp-runtime/try-runtime",
+]

--- a/frame/collator-rewards/README.md
+++ b/frame/collator-rewards/README.md
@@ -1,0 +1,109 @@
+# `robonomics-collator-rewards`
+
+A small, runtime-agnostic helper that mints a fixed per-block reward
+directly to the block author (collator) every time the runtime's
+[`pallet_authorship`] notifies a new author.
+
+It exposes a single generic struct, `AuthorRewards<T, Reward, Currency>`,
+that implements `pallet_authorship::EventHandler<T::AccountId,
+BlockNumberFor<T>>` and is wired into a runtime's
+`pallet_authorship::Config::EventHandler` tuple.
+
+## Why this crate exists
+
+The Robonomics parachain pays its collators a fixed reward per authored
+block, derived from the cost of running the reference hardware (see issue
+[#510]). The arithmetic and the wiring are independent of any specific
+Robonomics runtime, so they live here:
+
+- The runtime crate stays small — it only declares the reward constant
+  and binds the generic to its concrete `Runtime` / `Balances`.
+- The behaviour is unit-tested against a minimal mock runtime instead of
+  the full Robonomics runtime.
+- The same logic can be reused by future Robonomics runtimes (e.g. on
+  Kusama) without copy-pasting.
+
+## Reward formula (Robonomics on Polkadot)
+
+```text
+reward_per_block = (server_cost_per_year × collators × 1.3)
+                 / blocks_per_year
+                 / XRT_price
+                ≈ (2040 × 7 × 1.3) / 4_505_143 / 1
+                ≈ 0.0042 XRT
+```
+
+Encoded in the smallest unit of XRT (9 decimals): `4_200_000`.
+
+The constant lives in the consuming runtime, not in this crate, because
+the right value depends on the chain's hardware/cost assumptions and the
+token's decimals. Each consumer picks its own `Reward` constant; this
+crate only knows how to mint it.
+
+When any of the inputs (server cost, minimum collator count, XRT price)
+changes significantly, update the constant in the runtime and bump
+`spec_version`.
+
+## Why mint directly to the author?
+
+`pallet_collator_selection::note_author` only forwards **half** of its
+pot to the current author — the other half stays in the pot. Routing
+this reward through the pot would silently halve the per-block reward
+seen by the collator. Minting directly to the author guarantees the
+author receives exactly `Reward::get()` per authored block.
+
+Consequently `AuthorRewards` **must** appear before `CollatorSelection`
+in the `pallet_authorship::Config::EventHandler` tuple so the author is
+paid regardless of the pot's state.
+
+## Wiring example
+
+```rust,ignore
+use frame_support::parameter_types;
+use robonomics_collator_rewards::AuthorRewards;
+
+parameter_types! {
+    /// 0.0042 XRT per block, 9 decimals — see issue #510 and MIGRATIONS.md.
+    pub const CollatorBlockReward: Balance = 4_200_000;
+}
+
+pub type CollatorAuthorRewards =
+    AuthorRewards<Runtime, CollatorBlockReward, Balances>;
+
+impl pallet_authorship::Config for Runtime {
+    type FindAuthor = pallet_session::FindAccountFromAuthorIndex<Self, Aura>;
+    // `CollatorAuthorRewards` MUST come first so the author receives the
+    // full `CollatorBlockReward` independently of the collator-selection
+    // pot.
+    type EventHandler = (CollatorAuthorRewards, CollatorSelection);
+}
+```
+
+## Weight accounting
+
+Each call to `note_author` performs one extra `System::Account` read +
+write to mint the reward. The crate registers that cost as
+`DispatchClass::Mandatory` weight via
+`register_extra_weight_unchecked`, so the parachain's per-block weight
+limits remain respected. The numeric overhead matches the benchmarked
+`pallet_balances::force_set_balance_creating` weight.
+
+## Error handling
+
+`mint_into` failure is logged via `defensive!` rather than panicking.
+With a sensible reward (well above the existential deposit) and
+`u128` total issuance the failure path is unreachable in practice;
+treating it defensively avoids bricking block production on an
+unexpected runtime invariant violation.
+
+## Testing
+
+```sh
+cargo test -p robonomics-collator-rewards
+```
+
+The tests run against a minimal mock runtime that contains only
+`frame_system` and `pallet_balances`.
+
+[`pallet_authorship`]: https://docs.rs/pallet-authorship
+[#510]: https://github.com/airalab/robonomics/issues/510

--- a/frame/collator-rewards/src/lib.rs
+++ b/frame/collator-rewards/src/lib.rs
@@ -119,7 +119,7 @@ where
         if let Err(e) = Currency::mint_into(&author, reward) {
             defensive!(
                 "failed to mint collator block reward to author",
-                (author, reward, e)
+                (&author, reward, e)
             );
         }
     }

--- a/frame/collator-rewards/src/lib.rs
+++ b/frame/collator-rewards/src/lib.rs
@@ -1,0 +1,126 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright 2018-2026 Robonomics Network <research@robonomics.network>
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+///////////////////////////////////////////////////////////////////////////////
+//! # Robonomics Collator Rewards
+//!
+//! A small, runtime-agnostic helper that mints a fixed per-block reward
+//! directly to the block author (collator) every time the runtime's
+//! `pallet_authorship` notifies a new author.
+//!
+//! See `README.md` for the rationale, formula, and wiring example.
+//!
+//! ## Why a dedicated crate?
+//!
+//! The reward logic is independent of any specific Robonomics runtime: it
+//! only needs an `AccountId`, a fungible currency, and a constant reward
+//! amount. Keeping it here keeps the runtime crate small and lets us test
+//! the behaviour in isolation against a minimal mock runtime.
+//!
+//! ## Why mint directly to the author?
+//!
+//! `pallet_collator_selection::note_author` only forwards **half** of the
+//! pot to the current author — the other half stays in the pot. Routing
+//! the reward via the pot would therefore silently halve the per-block
+//! reward seen by the collator. Minting directly to the author guarantees
+//! the author receives exactly `Reward::get()` per authored block.
+//!
+//! Consequently, `AuthorRewards` MUST be ordered **before**
+//! `CollatorSelection` in the `pallet_authorship::Config::EventHandler`
+//! tuple so the author is paid regardless of the pot's state.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use core::marker::PhantomData;
+
+use frame_support::{
+    defensive,
+    dispatch::DispatchClass,
+    traits::{
+        fungible::{Inspect, Mutate},
+        Get,
+    },
+    weights::Weight,
+};
+use frame_system::pallet_prelude::BlockNumberFor;
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+/// Balance type associated with `Currency` for accounts of `T`.
+pub type BalanceOf<T, Currency> =
+    <Currency as Inspect<<T as frame_system::Config>::AccountId>>::Balance;
+
+/// `pallet_authorship::EventHandler` that mints a fixed `Reward` to the
+/// block author each block.
+///
+/// Generic over:
+/// - `T`: a `frame_system::Config`-bearing runtime (provides `AccountId`,
+///   `BlockNumber`, and `DbWeight`).
+/// - `Reward`: a `Get` returning the per-block reward amount in the
+///   smallest unit of `Currency`.
+/// - `Currency`: the fungible used to mint the reward (e.g.
+///   `pallet_balances::Pallet<Runtime>`).
+///
+/// Wire it ahead of `pallet_collator_selection` in the `EventHandler`
+/// tuple so that the author is paid regardless of the pot's state — see
+/// the crate-level docs for the rationale.
+pub struct AuthorRewards<T, Reward, Currency>(PhantomData<(T, Reward, Currency)>);
+
+impl<T, Reward, Currency> pallet_authorship::EventHandler<T::AccountId, BlockNumberFor<T>>
+    for AuthorRewards<T, Reward, Currency>
+where
+    T: frame_system::Config,
+    Reward: Get<BalanceOf<T, Currency>>,
+    Currency: Mutate<T::AccountId>,
+    BalanceOf<T, Currency>: Copy,
+{
+    fn note_author(author: T::AccountId) {
+        // `note_author` runs from `on_initialize`. Account for the extra
+        // storage mutation (one read + one write on `System::Account`)
+        // performed by `mint_into` as mandatory weight so the block weight
+        // limits are respected. The `from_parts` overhead matches the
+        // benchmarked `pallet_balances::force_set_balance_creating`
+        // weight, which performs the same `System::Account` access
+        // pattern.
+        let mint_weight = T::DbWeight::get()
+            .reads_writes(1, 1)
+            .saturating_add(Weight::from_parts(25_000_000, 3593));
+        frame_system::Pallet::<T>::register_extra_weight_unchecked(
+            mint_weight,
+            DispatchClass::Mandatory,
+        );
+
+        let reward = Reward::get();
+
+        // Mint the per-block reward directly to the author.
+        //
+        // Failure should be impossible in normal operation: a sensible
+        // `Reward` is well above the existential deposit and the total
+        // issuance cannot overflow `Balance` (u128) within any realistic
+        // chain lifetime. We therefore log defensively rather than panic,
+        // to avoid bricking block production on an unexpected runtime
+        // invariant violation.
+        if let Err(e) = Currency::mint_into(&author, reward) {
+            defensive!(
+                "failed to mint collator block reward to author",
+                (author, reward, e)
+            );
+        }
+    }
+}

--- a/frame/collator-rewards/src/mock.rs
+++ b/frame/collator-rewards/src/mock.rs
@@ -1,0 +1,52 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright 2018-2026 Robonomics Network <research@robonomics.network>
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+///////////////////////////////////////////////////////////////////////////////
+//! Minimal mock runtime for testing `AuthorRewards`.
+
+use frame_support::{construct_runtime, derive_impl, parameter_types};
+
+pub type AccountId = u64;
+pub type Balance = u128;
+
+type Block = frame_system::mocking::MockBlock<Test>;
+
+construct_runtime!(
+    pub enum Test {
+        System: frame_system,
+        Balances: pallet_balances,
+    }
+);
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+    type Block = Block;
+    type AccountData = pallet_balances::AccountData<Balance>;
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
+impl pallet_balances::Config for Test {
+    type Balance = Balance;
+    type AccountStore = System;
+}
+
+parameter_types! {
+    /// Per-block reward used by tests: 4_200_000 (matches the Robonomics
+    /// runtime's 0.0042 XRT at 9 decimals).
+    pub const TestReward: Balance = 4_200_000;
+}
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+    use sp_runtime::BuildStorage;
+    frame_system::GenesisConfig::<Test>::default()
+        .build_storage()
+        .unwrap()
+        .into()
+}

--- a/frame/collator-rewards/src/tests.rs
+++ b/frame/collator-rewards/src/tests.rs
@@ -1,0 +1,85 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright 2018-2026 Robonomics Network <research@robonomics.network>
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+///////////////////////////////////////////////////////////////////////////////
+//! Behavioural tests for `AuthorRewards`.
+
+use crate::AuthorRewards;
+use crate::mock::{new_test_ext, AccountId, Balances, Test, TestReward};
+use frame_support::traits::fungible::Inspect;
+use pallet_authorship::EventHandler;
+
+type Subject = AuthorRewards<Test, TestReward, Balances>;
+
+/// The block author MUST receive the FULL `Reward`, not half of it.
+/// `pallet_collator_selection::note_author` only forwards HALF of its pot
+/// to the current author, so routing this reward via the pot would
+/// silently halve it. This pins the exact end balance to guard against
+/// regressions where the reward is accidentally re-routed through the
+/// pot.
+#[test]
+fn block_author_receives_full_reward() {
+    new_test_ext().execute_with(|| {
+        let author: AccountId = 7;
+        assert_eq!(<Balances as Inspect<AccountId>>::balance(&author), 0);
+
+        Subject::note_author(author);
+
+        assert_eq!(
+            <Balances as Inspect<AccountId>>::balance(&author),
+            4_200_000,
+        );
+    });
+}
+
+#[test]
+fn block_author_reward_is_cumulative_across_blocks() {
+    new_test_ext().execute_with(|| {
+        let author: AccountId = 9;
+        for _ in 0..10 {
+            Subject::note_author(author);
+        }
+        assert_eq!(
+            <Balances as Inspect<AccountId>>::balance(&author),
+            4_200_000 * 10,
+        );
+    });
+}
+
+/// The mandatory weight registered by `note_author` must be reflected in
+/// `frame_system::BlockWeight` so the parachain weight limits are
+/// respected.
+#[test]
+fn note_author_registers_extra_weight() {
+    new_test_ext().execute_with(|| {
+        let before = frame_system::Pallet::<Test>::block_weight().total();
+        Subject::note_author(1);
+        let after = frame_system::Pallet::<Test>::block_weight().total();
+        assert!(
+            after.ref_time() > before.ref_time(),
+            "extra weight for the mint must be accounted for",
+        );
+    });
+}
+
+/// Different authors accrue independent balances.
+#[test]
+fn distinct_authors_accrue_independently() {
+    new_test_ext().execute_with(|| {
+        let a: AccountId = 11;
+        let b: AccountId = 22;
+        Subject::note_author(a);
+        Subject::note_author(a);
+        Subject::note_author(b);
+
+        assert_eq!(<Balances as Inspect<AccountId>>::balance(&a), 4_200_000 * 2);
+        assert_eq!(<Balances as Inspect<AccountId>>::balance(&b), 4_200_000);
+    });
+}

--- a/runtime/robonomics/Cargo.toml
+++ b/runtime/robonomics/Cargo.toml
@@ -69,6 +69,7 @@ pallet-robonomics-rws.workspace = true
 pallet-robonomics-cps.workspace = true
 pallet-robonomics-claim.workspace = true
 pallet-robonomics-teleport.workspace = true
+robonomics-collator-rewards.workspace = true
 
 # cumulus dependencies
 cumulus-pallet-aura-ext.workspace = true
@@ -151,6 +152,7 @@ std = [
   "pallet-robonomics-claim/std",
   "pallet-robonomics-cps/std",
   "pallet-robonomics-teleport/std",
+  "robonomics-collator-rewards/std",
   "pallet-sudo/std",
   "cumulus-pallet-aura-ext/std",
   "cumulus-pallet-parachain-system/std",
@@ -230,6 +232,7 @@ try-runtime = [
   "pallet-robonomics-rws/try-runtime",
   "pallet-robonomics-cps/try-runtime",
   "pallet-robonomics-teleport/try-runtime",
+  "robonomics-collator-rewards/try-runtime",
   "pallet-robonomics-claim/try-runtime",
   "parachain-info/try-runtime",
   "sp-runtime/try-runtime",

--- a/runtime/robonomics/src/lib.rs
+++ b/runtime/robonomics/src/lib.rs
@@ -35,13 +35,15 @@ extern crate alloc;
 use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::AggregateMessageOrigin;
 use frame_support::{
+    defensive,
     derive_impl,
     dispatch::DispatchClass,
     genesis_builder_helper::{build_state, get_preset},
     parameter_types,
     traits::{
-        fungible, tokens::imbalance::ResolveTo, ConstBool, ConstU32, ConstU64, Imbalance,
-        OnUnbalanced, WithdrawReasons,
+        fungible::{self, Mutate},
+        tokens::imbalance::ResolveTo,
+        ConstBool, ConstU32, ConstU64, Imbalance, OnUnbalanced, WithdrawReasons,
     },
     weights::{ConstantMultiplier, Weight},
     PalletId,
@@ -80,7 +82,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: alloc::borrow::Cow::Borrowed("robonomics"),
     impl_name: alloc::borrow::Cow::Borrowed("robonomics-airalab"),
     authoring_version: 1,
-    spec_version: 42,
+    spec_version: 43,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,
@@ -109,6 +111,60 @@ impl frame_support::traits::Contains<RuntimeCall> for BaseFilter {
             // These modules are not allowed to be called by transactions:
             // Other modules should works:
             _ => true,
+        }
+    }
+}
+
+/// Per-block reward minted directly to the block author (collator).
+///
+/// Derivation (see `MIGRATIONS.md` and issue #510):
+///   reward = (server_cost_per_year * collators * 1.3) / blocks_per_year / XRT_price
+///          = (2040 * 7 * 1.3) / 4_505_143 / 1
+///          ≈ 0.0042 XRT
+///
+/// Encoded in the smallest unit (XRT has 9 decimals, so 0.0042 XRT = 4_200_000).
+pub const COLLATOR_BLOCK_REWARD: Balance = 4_200_000;
+
+/// `pallet_authorship::EventHandler` that mints `COLLATOR_BLOCK_REWARD` directly
+/// to the block author.
+///
+/// Minting goes straight to the author (rather than into the
+/// `pallet_collator_selection` pot) because `pallet_collator_selection::note_author`
+/// pays only HALF of the pot to the current author — routing the reward via the
+/// pot would halve the per-block reward seen by the collator. Minting directly
+/// guarantees the author receives exactly `COLLATOR_BLOCK_REWARD` per authored
+/// block.
+///
+/// This handler MUST be ordered before `CollatorSelection` in the
+/// `pallet_authorship::Config::EventHandler` tuple so that the author is paid
+/// regardless of the pot's state.
+pub struct AuthorRewards;
+impl pallet_authorship::EventHandler<AccountId, BlockNumber> for AuthorRewards {
+    fn note_author(author: AccountId) {
+        // `note_author` runs from `on_initialize`. Account for the extra storage
+        // mutation (one read + one write on `System::Account`) as mandatory weight
+        // so the block weight limits are respected. The numbers below are taken
+        // from the benchmarked `pallet_balances::force_set_balance_creating`
+        // weight, which performs the same `System::Account` access pattern.
+        let mint_weight = <Runtime as frame_system::Config>::DbWeight::get()
+            .reads_writes(1, 1)
+            .saturating_add(Weight::from_parts(25_000_000, 3593));
+        frame_system::Pallet::<Runtime>::register_extra_weight_unchecked(
+            mint_weight,
+            DispatchClass::Mandatory,
+        );
+
+        // Mint the per-block reward to the author. Failure should be impossible
+        // here: `COLLATOR_BLOCK_REWARD` is well above the existential deposit and
+        // the total issuance cannot overflow `Balance` (u128) within any
+        // realistic chain lifetime. We therefore log defensively rather than
+        // panic, to avoid bricking block production on an unexpected runtime
+        // invariant violation.
+        if let Err(e) = <Balances as Mutate<AccountId>>::mint_into(&author, COLLATOR_BLOCK_REWARD) {
+            defensive!(
+                "failed to mint collator block reward to author",
+                (author, COLLATOR_BLOCK_REWARD, e)
+            );
         }
     }
 }
@@ -211,7 +267,9 @@ impl pallet_timestamp::Config for Runtime {
 
 impl pallet_authorship::Config for Runtime {
     type FindAuthor = pallet_session::FindAccountFromAuthorIndex<Self, Aura>;
-    type EventHandler = (CollatorSelection,);
+    // `AuthorRewards` MUST come first so the author receives the full
+    // `COLLATOR_BLOCK_REWARD` independently of the collator-selection pot.
+    type EventHandler = (AuthorRewards, CollatorSelection);
 }
 
 parameter_types! {
@@ -1196,4 +1254,79 @@ impl_runtime_apis! {
 cumulus_pallet_parachain_system::register_validate_block! {
     Runtime = Runtime,
     BlockExecutor = cumulus_pallet_aura_ext::BlockExecutor::<Runtime, Executive>,
+}
+
+#[cfg(test)]
+mod author_rewards_tests {
+    use super::*;
+    use frame_support::traits::fungible::Inspect;
+    use pallet_authorship::EventHandler;
+
+    fn new_test_ext() -> sp_io::TestExternalities {
+        frame_system::GenesisConfig::<Runtime>::default()
+            .build_storage()
+            .unwrap()
+            .into()
+    }
+
+    /// Reward constant must encode exactly 0.0042 XRT per block.
+    ///
+    /// XRT has 9 decimals, so 0.0042 XRT == 4_200_000 in the smallest unit.
+    /// See `MIGRATIONS.md` and issue #510 for the full derivation.
+    #[test]
+    fn reward_constant_matches_specification() {
+        assert_eq!(COLLATOR_BLOCK_REWARD, 4_200_000);
+        // 0.0042 XRT == 42 * (XRT / 10_000).
+        assert_eq!(COLLATOR_BLOCK_REWARD, 42 * (XRT / 10_000));
+    }
+
+    /// The block author MUST receive the FULL `COLLATOR_BLOCK_REWARD`, not half
+    /// of it. `pallet_collator_selection::note_author` only forwards HALF of its
+    /// pot to the current author, so routing this reward via the pot would
+    /// silently halve it. This test pins the exact end balance to guard against
+    /// regressions where the reward is accidentally re-routed through the pot.
+    #[test]
+    fn block_author_receives_full_reward() {
+        new_test_ext().execute_with(|| {
+            let author: AccountId = AccountId::from([7u8; 32]);
+            assert_eq!(<Balances as Inspect<AccountId>>::balance(&author), 0);
+
+            AuthorRewards::note_author(author.clone());
+
+            assert_eq!(
+                <Balances as Inspect<AccountId>>::balance(&author),
+                COLLATOR_BLOCK_REWARD,
+            );
+        });
+    }
+
+    #[test]
+    fn block_author_reward_is_cumulative_across_blocks() {
+        new_test_ext().execute_with(|| {
+            let author: AccountId = AccountId::from([9u8; 32]);
+            for _ in 0..10 {
+                AuthorRewards::note_author(author.clone());
+            }
+            assert_eq!(
+                <Balances as Inspect<AccountId>>::balance(&author),
+                COLLATOR_BLOCK_REWARD * 10,
+            );
+        });
+    }
+
+    /// The mandatory weight registered by `AuthorRewards::note_author` must be
+    /// reflected in `frame_system::BlockWeight` so that the parachain weight
+    /// limits are respected.
+    #[test]
+    fn note_author_registers_extra_weight() {
+        new_test_ext().execute_with(|| {
+            let before = frame_system::Pallet::<Runtime>::block_weight().total();
+            AuthorRewards::note_author(AccountId::from([1u8; 32]));
+            let after = frame_system::Pallet::<Runtime>::block_weight().total();
+            assert!(
+                after.ref_time() > before.ref_time(),
+                "extra weight for the mint must be accounted for",
+            );
+        });
+    }
 }

--- a/runtime/robonomics/src/lib.rs
+++ b/runtime/robonomics/src/lib.rs
@@ -113,15 +113,15 @@ impl frame_support::traits::Contains<RuntimeCall> for BaseFilter {
     }
 }
 
-/// Per-block reward minted directly to the block author (collator).
-///
-/// Derivation (see `MIGRATIONS.md` and issue #510):
-///   reward = (server_cost_per_year * collators * 1.3) / blocks_per_year / XRT_price
-///          = (2040 * 7 * 1.3) / 4_505_143 / 1
-///          ≈ 0.0042 XRT
-///
-/// Encoded in the smallest unit (XRT has 9 decimals, so 0.0042 XRT = 4_200_000).
 parameter_types! {
+    /// Per-block reward minted directly to the block author (collator).
+    ///
+    /// Derivation (see `MIGRATIONS.md` and issue #510):
+    ///   reward = (server_cost_per_year * collators * 1.3) / blocks_per_year / XRT_price
+    ///          = (2040 * 7 * 1.3) / 4_505_143 / 1
+    ///          ≈ 0.0042 XRT
+    ///
+    /// Encoded in the smallest unit (XRT has 9 decimals, so 0.0042 XRT = 4_200_000).
     pub const CollatorBlockReward: Balance = 4_200_000;
 }
 

--- a/runtime/robonomics/src/lib.rs
+++ b/runtime/robonomics/src/lib.rs
@@ -35,15 +35,13 @@ extern crate alloc;
 use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::AggregateMessageOrigin;
 use frame_support::{
-    defensive,
     derive_impl,
     dispatch::DispatchClass,
     genesis_builder_helper::{build_state, get_preset},
     parameter_types,
     traits::{
-        fungible::{self, Mutate},
-        tokens::imbalance::ResolveTo,
-        ConstBool, ConstU32, ConstU64, Imbalance, OnUnbalanced, WithdrawReasons,
+        fungible, tokens::imbalance::ResolveTo, ConstBool, ConstU32, ConstU64, Imbalance,
+        OnUnbalanced, WithdrawReasons,
     },
     weights::{ConstantMultiplier, Weight},
     PalletId,
@@ -123,51 +121,21 @@ impl frame_support::traits::Contains<RuntimeCall> for BaseFilter {
 ///          ≈ 0.0042 XRT
 ///
 /// Encoded in the smallest unit (XRT has 9 decimals, so 0.0042 XRT = 4_200_000).
-pub const COLLATOR_BLOCK_REWARD: Balance = 4_200_000;
-
-/// `pallet_authorship::EventHandler` that mints `COLLATOR_BLOCK_REWARD` directly
-/// to the block author.
-///
-/// Minting goes straight to the author (rather than into the
-/// `pallet_collator_selection` pot) because `pallet_collator_selection::note_author`
-/// pays only HALF of the pot to the current author — routing the reward via the
-/// pot would halve the per-block reward seen by the collator. Minting directly
-/// guarantees the author receives exactly `COLLATOR_BLOCK_REWARD` per authored
-/// block.
-///
-/// This handler MUST be ordered before `CollatorSelection` in the
-/// `pallet_authorship::Config::EventHandler` tuple so that the author is paid
-/// regardless of the pot's state.
-pub struct AuthorRewards;
-impl pallet_authorship::EventHandler<AccountId, BlockNumber> for AuthorRewards {
-    fn note_author(author: AccountId) {
-        // `note_author` runs from `on_initialize`. Account for the extra storage
-        // mutation (one read + one write on `System::Account`) as mandatory weight
-        // so the block weight limits are respected. The numbers below are taken
-        // from the benchmarked `pallet_balances::force_set_balance_creating`
-        // weight, which performs the same `System::Account` access pattern.
-        let mint_weight = <Runtime as frame_system::Config>::DbWeight::get()
-            .reads_writes(1, 1)
-            .saturating_add(Weight::from_parts(25_000_000, 3593));
-        frame_system::Pallet::<Runtime>::register_extra_weight_unchecked(
-            mint_weight,
-            DispatchClass::Mandatory,
-        );
-
-        // Mint the per-block reward to the author. Failure should be impossible
-        // here: `COLLATOR_BLOCK_REWARD` is well above the existential deposit and
-        // the total issuance cannot overflow `Balance` (u128) within any
-        // realistic chain lifetime. We therefore log defensively rather than
-        // panic, to avoid bricking block production on an unexpected runtime
-        // invariant violation.
-        if let Err(e) = <Balances as Mutate<AccountId>>::mint_into(&author, COLLATOR_BLOCK_REWARD) {
-            defensive!(
-                "failed to mint collator block reward to author",
-                (author, COLLATOR_BLOCK_REWARD, e)
-            );
-        }
-    }
+parameter_types! {
+    pub const CollatorBlockReward: Balance = 4_200_000;
 }
+
+/// `pallet_authorship::EventHandler` that mints `CollatorBlockReward` directly
+/// to the block author. The implementation lives in
+/// `robonomics-collator-rewards`; see that crate's README for the rationale
+/// (notably why we mint to the author rather than the collator-selection pot).
+///
+/// MUST be ordered before `CollatorSelection` in the `EventHandler` tuple.
+pub type AuthorRewards = robonomics_collator_rewards::AuthorRewards<
+    Runtime,
+    CollatorBlockReward,
+    Balances,
+>;
 
 /// Fungible implementation of `OnUnbalanced` that deals with the fees.
 pub struct DealWithFees;
@@ -268,7 +236,7 @@ impl pallet_timestamp::Config for Runtime {
 impl pallet_authorship::Config for Runtime {
     type FindAuthor = pallet_session::FindAccountFromAuthorIndex<Self, Aura>;
     // `AuthorRewards` MUST come first so the author receives the full
-    // `COLLATOR_BLOCK_REWARD` independently of the collator-selection pot.
+    // `CollatorBlockReward` independently of the collator-selection pot.
     type EventHandler = (AuthorRewards, CollatorSelection);
 }
 
@@ -1259,74 +1227,18 @@ cumulus_pallet_parachain_system::register_validate_block! {
 #[cfg(test)]
 mod author_rewards_tests {
     use super::*;
-    use frame_support::traits::fungible::Inspect;
-    use pallet_authorship::EventHandler;
-
-    fn new_test_ext() -> sp_io::TestExternalities {
-        frame_system::GenesisConfig::<Runtime>::default()
-            .build_storage()
-            .unwrap()
-            .into()
-    }
+    use frame_support::traits::Get;
 
     /// Reward constant must encode exactly 0.0042 XRT per block.
     ///
     /// XRT has 9 decimals, so 0.0042 XRT == 4_200_000 in the smallest unit.
-    /// See `MIGRATIONS.md` and issue #510 for the full derivation.
+    /// Behavioural tests for the handler itself live in
+    /// `robonomics-collator-rewards`; this test only pins the chain-specific
+    /// constant. See `MIGRATIONS.md` and issue #510 for the full derivation.
     #[test]
     fn reward_constant_matches_specification() {
-        assert_eq!(COLLATOR_BLOCK_REWARD, 4_200_000);
+        assert_eq!(<CollatorBlockReward as Get<Balance>>::get(), 4_200_000);
         // 0.0042 XRT == 42 * (XRT / 10_000).
-        assert_eq!(COLLATOR_BLOCK_REWARD, 42 * (XRT / 10_000));
-    }
-
-    /// The block author MUST receive the FULL `COLLATOR_BLOCK_REWARD`, not half
-    /// of it. `pallet_collator_selection::note_author` only forwards HALF of its
-    /// pot to the current author, so routing this reward via the pot would
-    /// silently halve it. This test pins the exact end balance to guard against
-    /// regressions where the reward is accidentally re-routed through the pot.
-    #[test]
-    fn block_author_receives_full_reward() {
-        new_test_ext().execute_with(|| {
-            let author: AccountId = AccountId::from([7u8; 32]);
-            assert_eq!(<Balances as Inspect<AccountId>>::balance(&author), 0);
-
-            AuthorRewards::note_author(author.clone());
-
-            assert_eq!(
-                <Balances as Inspect<AccountId>>::balance(&author),
-                COLLATOR_BLOCK_REWARD,
-            );
-        });
-    }
-
-    #[test]
-    fn block_author_reward_is_cumulative_across_blocks() {
-        new_test_ext().execute_with(|| {
-            let author: AccountId = AccountId::from([9u8; 32]);
-            for _ in 0..10 {
-                AuthorRewards::note_author(author.clone());
-            }
-            assert_eq!(
-                <Balances as Inspect<AccountId>>::balance(&author),
-                COLLATOR_BLOCK_REWARD * 10,
-            );
-        });
-    }
-
-    /// The mandatory weight registered by `AuthorRewards::note_author` must be
-    /// reflected in `frame_system::BlockWeight` so that the parachain weight
-    /// limits are respected.
-    #[test]
-    fn note_author_registers_extra_weight() {
-        new_test_ext().execute_with(|| {
-            let before = frame_system::Pallet::<Runtime>::block_weight().total();
-            AuthorRewards::note_author(AccountId::from([1u8; 32]));
-            let after = frame_system::Pallet::<Runtime>::block_weight().total();
-            assert!(
-                after.ref_time() > before.ref_time(),
-                "extra weight for the mint must be accounted for",
-            );
-        });
+        assert_eq!(<CollatorBlockReward as Get<Balance>>::get(), 42 * (XRT / 10_000));
     }
 }


### PR DESCRIPTION
Fixes #510

## Summary

Implements a fixed per-block collator reward of 0.0042 XRT, calculated from the cost model in issue #510.

## Approach

- Mint directly to the block author (not the collator-selection pot, which only forwards half to the author)
- Register mandatory weight for the extra balance mutation
- Use defensive error handling instead of silently ignoring mint failures

## Changes

- `runtime/robonomics/src/lib.rs` — `AuthorRewards` event handler, wired before `CollatorSelection`
- `MIGRATIONS.md` — documented formula, parameters, and revision criteria

## Tests

4 unit tests covering: exact reward constant, full author payout, cumulative behavior, and weight registration.
